### PR TITLE
Set output option to "export" in Next.js configuration

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,7 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: "export",
 };
 
 export default nextConfig;


### PR DESCRIPTION
This pull request includes a small change to the `next.config.ts` file. The change sets the `output` configuration option to "export".

* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL4-R4): Set the `output` configuration option to "export".